### PR TITLE
[FIX] Load gems properly

### DIFF
--- a/lgtm-generator-from-dropbox.rb
+++ b/lgtm-generator-from-dropbox.rb
@@ -1,3 +1,4 @@
+require 'bundler/setup'
 require 'dropbox_api'
 require 'RMagick'
 require 'json'


### PR DESCRIPTION
```
$ ruby lgtm-generator-from-dropbox.rb
Traceback (most recent call last):
	2: from lgtm-generator-from-dropbox.rb:1:in `<main>'
	1: from /Users/(snip)/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
/Users/(snip)/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require': cannot load such file -- dropbox_api (LoadError)
```

c.f.) https://bundler.io/v1.12/bundler_setup.html