### PR TITLE
Feature/add border on LGTM string

### DIFF
--- a/lib/generator.rb
+++ b/lib/generator.rb
@@ -7,6 +7,7 @@ module Generator
       Magick::Draw.new {
         self.font = 'Helvetica'
         self.font_weight = Magick::BoldWeight
+        self.stroke = 'black'
         self.gravity = Magick::SouthEastGravity
       }
     end


### PR DESCRIPTION
Add black border on string to see "LGTM" easily.

![output](https://user-images.githubusercontent.com/8979468/49367168-9d097880-f72e-11e8-8a29-2e75f4bba7b1.jpg)
