### PR TITLE
Feature: use Gif image on Dropbox as original image

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,18 @@ Generate LGTM image from your favorite images on [Dropbox](http://dropbox.com) !
   + Select "LGTM" text color automatically.
   + Change "LGTM" text itself.
   + Set semi-transparent background under "LGTM" text.
+	+ Use Gif image as original one.
   + Resize the image.
   + Generate Gif image.
   + Upload the image to [Gyazo](https://gyazo.com).
   + Consider the usage frequency.
+
+## Notes 2018/12
+
+`--gif` option has been obsoleted.  
+To add gif text on image, use `--text-gif`.
+
+If you want to use Gif image on Dropbox, use `--use-gif` option.
 
 ## Usage
 
@@ -88,6 +96,14 @@ Use `--background` option
 $ ruby lgtm-generator-from-dropbox.rb --background
 ```
 
+### Use Gif as original image on Dropbox
+
+Use `--use-gif` option
+
+```sh
+$ ruby lgtm-generator-from-dropbox.rb --use-gif
+```
+
 ### Change LGTM image size
 
 Use `--size` option  
@@ -99,10 +115,10 @@ $ ruby lgtm-generator-from-dropbox.rb --size 640x480
 
 ### Generate LGTM gif
 
-Use `--gif` option
+Use `--text-gif` option
 
 ```sh
-$ ruby lgtm-generator-from-dropbox.rb --gif
+$ ruby lgtm-generator-from-dropbox.rb --text-gif
 # output.gif will be generated instead
 ```
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ $ ruby lgtm-generator-from-dropbox.rb --background
 
 ### Use Gif as original image on Dropbox
 
-Use `--use-gif` option
+Use `--use-gif` option  
+Only `.gif` image will be selected as the original image.
 
 ```sh
 $ ruby lgtm-generator-from-dropbox.rb --use-gif

--- a/lgtm-generator-from-dropbox.rb
+++ b/lgtm-generator-from-dropbox.rb
@@ -93,17 +93,25 @@ client = DropboxApi::Client.new(
 
 puts 'Reading Dropbox files ...'
 file_list = client.list_folder(json_data['target_directory'], recursive: true)
+filename_list = file_list.entries
 
 # Get an image randomly in the directory
+# If `use-gif` option is enabled, Only .gif image will be selected
 # If `history` option is enabled, The least frequently used image will be adopted
+if params['use-gif']
+  filename_list = filename_list.select { |file|
+    File.extname(file.name) == '.gif'
+  }
+end
+
 if params['history']
   while true
-    file_name = file_list.entries.sample.name
+    file_name = filename_list.sample.name
     puts 'Check by history: ' + file_name
     break if History.should_adopt?(file_name)
   end
 else
-  file_name = file_list.entries.sample.name
+  file_name = filename_list.sample.name
 end
 puts 'Adopt: ' + file_name
 download_image_name = json_data['target_directory'] + file_name

--- a/lib/generator.rb
+++ b/lib/generator.rb
@@ -59,6 +59,9 @@ module Generator
     # duck type
     def generate!(img:, text:, font_size:, color:, output_file:, cjk_font:, background:)
       list = Magick::ImageList.new(img.filename)
+      # Each image in the new imagelist is formed by flattening all the previous images.
+      list = list.coalesce
+
       list.each { |frame|
         drawer.annotate(frame, 0, 0, 0, 0, text) do
           self.font = cjk_font if text.contains_cjk?
@@ -67,6 +70,8 @@ module Generator
         end
       }
 
+      # Optimize the images in the list
+      list = list.optimize_layers(Magick::OptimizeLayer)
       list.write(output_file)
     end
   end

--- a/lib/generator.rb
+++ b/lib/generator.rb
@@ -58,6 +58,25 @@ module Generator
 
     # duck type
     def generate!(img:, text:, font_size:, color:, output_file:, cjk_font:, background:)
+      list = Magick::ImageList.new(img.filename)
+      list.each { |frame|
+        drawer.annotate(frame, 0, 0, 0, 0, text) do
+          self.font = cjk_font if text.contains_cjk?
+          self.pointsize = font_size
+          self.fill = color
+        end
+      }
+
+      list.write(output_file)
+    end
+  end
+
+  module TextGif
+    extend Base
+    module_function
+
+    # duck type
+    def generate!(img:, text:, font_size:, color:, output_file:, cjk_font:, background:)
       image_list = Magick::ImageList.new.tap do |list|
         offsets.each do |offset_x|
           cloned = img.dup


### PR DESCRIPTION
+ Add `--use-gif` option to use Gif image.
+ Change `--gif` option into `--text-gif` option.

Output example of `ruby lgtm-generator-from-dropbox.rb --use-gif --auto-color`

![output](https://user-images.githubusercontent.com/8979468/50055668-40c64000-0195-11e9-82c9-66dea33dbfcb.gif)
